### PR TITLE
properly calculate size of buffer

### DIFF
--- a/src/net/matrix-udp-rx.c
+++ b/src/net/matrix-udp-rx.c
@@ -217,8 +217,7 @@ main(
 		if (frame_part == 0xff) {
 			// Set packets_per_frame
 			if ((size_t)rlen != 2) {
-				warn("WARNING: Recieved PPF packet of %zu bytes, expected 2
-n",rlen);
+				warn("WARNING: Recieved PPF packet of %zu bytes, expected 2\n",rlen);
 			} else {
 				packets_per_frame = buf[1];
 			}

--- a/src/net/matrix-udp-rx.c
+++ b/src/net/matrix-udp-rx.c
@@ -222,11 +222,12 @@ main(
 				packets_per_frame = buf[1];
 			}
 			continue;
-		} else if (frame_page >= packets_per_frame) {
+		} else if (frame_part >= packets_per_frame) {
 			printf("frame part out of range: %d (max %d)\n", frame_part, packets_per_frame);
 			continue;
 		}
-
+		const unsigned int pixels_per_packet = (width * height)/packets_per_frame;
+		const unsigned image_part_size = pixels_per_packet * 3;
 		if ((size_t) rlen != image_part_size + 1)
 		{
 			warn_once("WARNING: Received packet %zu bytes, expected %zu\n",
@@ -242,7 +243,6 @@ main(
 
 		// copy the 3-byte values into the 4-byte framebuffer
 		// and turn onto the side
-		unsigned int pixels_per_packet = (width * height)/packets_per_frame;
 		unsigned fb_offset = pixels_per_packet * frame_part;
 
 		for (unsigned i = 0 ; i < pixels_per_packet ; i++) {

--- a/src/net/matrix-udp-rx.c
+++ b/src/net/matrix-udp-rx.c
@@ -84,6 +84,8 @@ static void usage(void)
 }
 
 
+const unsigned int packets_per_frame = 2;
+
 int
 main(
 	int argc,
@@ -146,9 +148,10 @@ main(
 		die("socket port %d failed: %s\n", port, strerror(errno));
 
 	const size_t image_size = width * height * 3;
+	const size_t buf_size = (width*height*4)/packets_per_frame + 1;
 
 	// largest possible UDP packet
-	uint8_t *buf = calloc(width*height,4);
+	uint8_t *buf = malloc(buf_size);
 #if 0
 	if (sizeof(buf) < image_size + 1)
 		die("%u x %u too large for UDP\n", width, height);
@@ -205,7 +208,7 @@ main(
 			continue;
 		}
 
-		const ssize_t rlen = recv(sock, buf, sizeof(buf), 0);
+		const ssize_t rlen = recv(sock, buf, buf_size, 0);
 		if (rlen < 0)
 			die("recv failed: %s\n", strerror(errno));
 		warn_once("received %zu bytes\n", rlen);

--- a/src/net/matrix-udp-rx.c
+++ b/src/net/matrix-udp-rx.c
@@ -148,10 +148,10 @@ main(
 		die("socket port %d failed: %s\n", port, strerror(errno));
 
 	const size_t image_size = width * height * 3;
-	const size_t buf_size = (width*height*4)/packets_per_frame + 1;
+	const size_t buf_size = (width*height*3)/packets_per_frame + 1;
 
 	// largest possible UDP packet
-	uint8_t *buf = malloc(buf_size);
+	uint8_t *buf = calloc(buf_size,1);
 #if 0
 	if (sizeof(buf) < image_size + 1)
 		die("%u x %u too large for UDP\n", width, height);


### PR DESCRIPTION
Getting four bytes per packet because we're getting four bytes per packet. 
:expressionless: