### PR TITLE
Fixed offset of second frame part

### DIFF
--- a/src/net/matrix-udp-rx.c
+++ b/src/net/matrix-udp-rx.c
@@ -237,7 +237,7 @@ main(
 		{
 			for (unsigned y = 0 ; y < height ; y++) // 64
 			{
-				uint32_t * out = &fb[(height*frame_part + y)*width + x];
+				uint32_t * out = &fb[(height*frame_part/2 + y)*width + x];
 				const uint8_t * in = &buf[1 + 3*(y*width + x)];
 
 				uint8_t r = in[0];


### PR DESCRIPTION
Offset was height x frame_part x width, which is on the second frame part height x width, so out of drawing frame. Should be just the second half of the image.