### PR TITLE
Introduce a memory barrier between writing the DMA address and the command.

### DIFF
--- a/src/ledscape/ledscape.c
+++ b/src/ledscape/ledscape.c
@@ -350,6 +350,8 @@ ledscape_strip_draw(
 		= leds->pru->ddr_addr + leds->frame_size * frame;
 //	frame = (frame + 1) & 1;
 
+	__asm__ __volatile__("":::"memory");
+
 	// Send the start command
 	leds->ws281x->command = 1;
 }


### PR DESCRIPTION
Without a memory barrier gcc is free to reorder volatile stores. In my case
the LED strip lit up with uninitialized memory for the first draw and then
fixed itself with the next one. With this change it was immediately fixed.